### PR TITLE
feat: 放置PR検知からPR状況共有ツールへピボット

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -2,7 +2,7 @@ name: PR Review Reminder
 
 on:
   schedule:
-    - cron: '0 23 * * 0-4' # 平日 08:00 JST (23:00 UTC 前日)
+    - cron: '0 23 * * 0,2,4' # 月水金 08:00 JST (前日 23:00 UTC)
   workflow_dispatch: {} # 手動実行用
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PRの状態をチェックし、Slackにリマインダーを送るBot。
 - 自分のPR: レビュー待ち・修正待ち・マージ可能などのステータスを通知
 - レビュー依頼: 自分がレビュアーに設定されている他人のPRを通知
 
-GitHub Actions cron（平日8:00 JST）で自動実行。該当PRが0件なら「対象PRなし」を通知。
+GitHub Actions cron（月・水・金 8:00 JST）で自動実行。該当PRが0件なら「対象PRなし」を通知。
 
 ## 通知イメージ
 
@@ -69,13 +69,11 @@ Actions > PR Review Reminder > Run workflow で手動実行。
 
 ## カスタマイズ
 
-**経過日数** — ワークフローの env に `STALE_DAYS` を追加（デフォルト: 2）
-
 **実行スケジュール** — `.github/workflows/pr-review-reminder.yml` の cron を変更
 
 ```yaml
 schedule:
-  - cron: '0 23 * * 0-4'  # 平日 08:00 JST (UTC+9)
+  - cron: '0 23 * * 0,2,4'  # 月水金 08:00 JST (前日 23:00 UTC)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
 # PR Review Reminder
 
-自分のPRがレビューされずに放置されていないかチェックし、Slackに通知するBot。
+PRの状態をチェックし、Slackにリマインダーを送るBot。
 
-GitHub Actions cron（平日9:30 JST）で自動実行。該当PRが0件なら通知しない。
+- 自分のPR: レビュー待ち・修正待ち・マージ可能などのステータスを通知
+- レビュー依頼: 自分がレビュアーに設定されている他人のPRを通知
+
+GitHub Actions cron（平日8:00 JST）で自動実行。該当PRが0件なら「対象PRなし」を通知。
 
 ## 通知イメージ
 
 ```
-👀 レビュー待ちPRリマインダー
+👀 PRリマインダー
 
-2日以上レビューされていないPRがあります:
-
+── 自分のPR ──
 my-api
+⏳ レビュー待ち | #142 feat: add billing endpoint | 5日経過 | Reviewer: alice
+✅ マージ可能 | #456 approved PR title
+✏️ 修正待ち | #138 fix: correct tax calculation | 3日経過 | Reviewer: bob
 
-#142 feat: add billing endpoint
-- 5日経過
-- Reviewer: alice
-- ⏳ レビュー待ち
-
-#138 fix: correct tax calculation
-- 3日経過
-- Reviewer: bob
-- 🔄 再レビュー依頼忘れ
+── レビュー依頼 ──
+frontend
+🔍 レビューしてね | #321 feat: new dashboard | 2日経過
 ```
 
 ### ステータス一覧
@@ -32,6 +31,8 @@ my-api
 | ✏️ 修正待ち | Changes Requested。自分が対応する番 |
 | 🔄 再レビュー依頼忘れ | 対応済みだがre-requestを送っていない |
 | ⚠️ Reviewer未設定 | レビュアーが設定されていない |
+| ✅ マージ可能 | Approveされており、マージできる状態 |
+| 🔍 レビューしてね | 自分がレビュアーに設定されている他人のPR |
 
 ## セットアップ
 
@@ -74,7 +75,7 @@ Actions > PR Review Reminder > Run workflow で手動実行。
 
 ```yaml
 schedule:
-  - cron: '30 0 * * 1-5'  # 平日 09:30 JST (UTC+9)
+  - cron: '0 23 * * 0-4'  # 平日 08:00 JST (UTC+9)
 ```
 
 ## License

--- a/scripts/check-stale-prs.sh
+++ b/scripts/check-stale-prs.sh
@@ -37,10 +37,15 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IFS=',' read -ra repos <<< "$TARGET_REPOS"
 
-blocks='[]'
-has_stale_prs=false
+# 自分のPR用ブロック（stale + approved）
+my_pr_blocks='[]'
+has_my_prs=false
+
+# レビュー依頼用ブロック
+reviewer_blocks='[]'
+has_reviewer_prs=false
+
 repo_success_count=0
-total_open_prs=0
 
 for repo in "${repos[@]}"; do
   repo=$(echo "$repo" | xargs)
@@ -48,7 +53,9 @@ for repo in "${repos[@]}"; do
 
   echo "${full_repo} を確認中..."
 
-  # コミット情報を除いたPR一覧を取得（GraphQLノード数制限の回避）
+  # ========================================
+  # 自分のPR一覧を取得
+  # ========================================
   if ! prs=$(gh pr list \
     --repo "$full_repo" \
     --state open \
@@ -59,8 +66,7 @@ for repo in "${repos[@]}"; do
     continue
   fi
 
-
-  # PR個別に最終コミット日を取得
+  # PR個別に最終コミット日を取得（Draft・APPROVEDも含む — jqフィルタで分類）
   prs_with_commits="[]"
   while IFS= read -r pr_number; do
     pr_data=$(echo "$prs" | jq --argjson n "$pr_number" '[.[] | select(.number == $n)][0]')
@@ -76,20 +82,20 @@ for repo in "${repos[@]}"; do
       pr_data=$(echo "$pr_data" | jq --arg lc "$created" '. + {commits: [{committedDate: $lc}]}')
     fi
     prs_with_commits=$(echo "$prs_with_commits" | jq --argjson pr "$pr_data" '. + [$pr]')
-  done < <(echo "$prs" | jq -r '.[] | select(.isDraft == false and .reviewDecision != "APPROVED") | .number')
+  done < <(echo "$prs" | jq -r '.[] | select(.isDraft == false) | .number')
 
   repo_success_count=$((repo_success_count + 1))
-  repo_open_count=$(echo "$prs" | jq 'length')
-  total_open_prs=$((total_open_prs + repo_open_count))
-  stale_prs=$(echo "$prs_with_commits" | jq -r --argjson now "$now" --argjson threshold "$threshold" --argjson ignore_reviewers "$ignore_json" -f "${SCRIPT_DIR}/filter-stale-prs.jq")
 
-  count=$(echo "$stale_prs" | jq 'length')
+  # jqフィルタで分類（approved + stale）
+  filtered_prs=$(echo "$prs_with_commits" | jq -r --argjson now "$now" --argjson threshold "$threshold" --argjson ignore_reviewers "$ignore_json" -f "${SCRIPT_DIR}/filter-stale-prs.jq")
+
+  count=$(echo "$filtered_prs" | jq 'length')
 
   if [[ "$count" -gt 0 ]]; then
-    has_stale_prs=true
+    has_my_prs=true
 
     # リポジトリ名のヘッダーブロック
-    blocks=$(echo "$blocks" | jq --arg repo "$repo" '. + [
+    my_pr_blocks=$(echo "$my_pr_blocks" | jq --arg repo "$repo" '. + [
       {"type": "context", "elements": [{"type": "mrkdwn", "text": ("*" + $repo + "*")}]}
     ]')
 
@@ -102,9 +108,10 @@ for repo in "${repos[@]}"; do
 
       case "$status_key" in
         review_pending)       status="⏳ レビュー待ち" ;;
-        changes_requested)    status="✏️ 修正待ち（自分が対応する番）" ;;
+        changes_requested)    status="✏️ 修正待ち" ;;
         re_request_forgotten) status="🔄 再レビュー依頼忘れ" ;;
         no_reviewer)          status="⚠️ Reviewer未設定" ;;
+        approved)             status="✅ マージ可能" ;;
         *)                    status="$status_key" ;;
       esac
 
@@ -115,21 +122,64 @@ for repo in "${repos[@]}"; do
         reviewers="未設定"
       fi
 
-      # PRリンクと詳細情報のブロック
-      blocks=$(echo "$blocks" | jq \
-        --arg url "$url" \
-        --arg number "$number" \
-        --arg title "$title" \
-        --arg days "$days" \
-        --arg reviewers "$reviewers" \
-        --arg status "$status" \
-        '. + [
-          {"type": "section", "text": {"type": "mrkdwn", "text": ("<" + $url + "|#" + $number + " " + $title + ">")}},
-          {"type": "context", "elements": [{"type": "mrkdwn", "text": ($days + "日経過  |  Reviewer: " + $reviewers + "  |  " + $status)}]}
-        ]')
-    done < <(echo "$stale_prs" | jq -c '.[]')
+      # ステータスごとにコンテキスト行を構築
+      if [[ "$status_key" == "approved" ]]; then
+        context_text="${status} | <${url}|#${number} ${title}>"
+      else
+        context_text="${status} | <${url}|#${number} ${title}> | ${days}日経過 | Reviewer: ${reviewers}"
+      fi
 
-    blocks=$(echo "$blocks" | jq '. + [{"type": "divider"}]')
+      my_pr_blocks=$(echo "$my_pr_blocks" | jq \
+        --arg text "$context_text" \
+        '. + [
+          {"type": "section", "text": {"type": "mrkdwn", "text": $text}}
+        ]')
+    done < <(echo "$filtered_prs" | jq -c '.[]')
+  fi
+
+  # ========================================
+  # レビュアーとして割り当てられたPRを取得
+  # ========================================
+  if ! reviewer_prs=$(gh pr list \
+    --repo "$full_repo" \
+    --state open \
+    --search "review-requested:${PR_AUTHOR}" \
+    --json number,title,url,createdAt,isDraft \
+    --limit 100 2>&1); then
+    echo "警告: ${full_repo} のレビュー依頼PR取得に失敗しました: ${reviewer_prs}" >&2
+    continue
+  fi
+
+  # Draft PRを除外し、経過日数を計算
+  reviewer_prs_filtered=$(echo "$reviewer_prs" | jq --argjson now "$now" '[
+    .[] | select(.isDraft == false) |
+    (.createdAt | fromdateiso8601) as $created |
+    . + { days_elapsed: ((($now - $created) / 86400) | floor) }
+  ] | sort_by(-.days_elapsed)')
+
+  reviewer_count=$(echo "$reviewer_prs_filtered" | jq 'length')
+
+  if [[ "$reviewer_count" -gt 0 ]]; then
+    has_reviewer_prs=true
+
+    reviewer_blocks=$(echo "$reviewer_blocks" | jq --arg repo "$repo" '. + [
+      {"type": "context", "elements": [{"type": "mrkdwn", "text": ("*" + $repo + "*")}]}
+    ]')
+
+    while IFS= read -r pr; do
+      url=$(echo "$pr" | jq -r '.url')
+      number=$(echo "$pr" | jq -r '.number')
+      title=$(echo "$pr" | jq -r '.title')
+      days=$(echo "$pr" | jq -r '.days_elapsed')
+
+      context_text="🔍 レビューしてね | <${url}|#${number} ${title}> | ${days}日経過"
+
+      reviewer_blocks=$(echo "$reviewer_blocks" | jq \
+        --arg text "$context_text" \
+        '. + [
+          {"type": "section", "text": {"type": "mrkdwn", "text": $text}}
+        ]')
+    done < <(echo "$reviewer_prs_filtered" | jq -c '.[]')
   fi
 done
 
@@ -138,22 +188,34 @@ if [[ "$repo_success_count" -eq 0 ]]; then
   exit 1
 fi
 
-if [[ "$has_stale_prs" == "false" ]]; then
-  all_blocks=$(jq -n \
-    --arg stale_days "$STALE_DAYS" \
-    --argjson total "$total_open_prs" \
-    '[
-      {"type": "header", "text": {"type": "plain_text", "text": "👀 レビュー待ちPRリマインダー"}},
-      {"type": "section", "text": {"type": "mrkdwn", "text": ("open PR: " + ($total | tostring) + "件\n" + $stale_days + "日以上レビューされていないPR: 0件")}}
-    ]')
-else
-  header_block=$(jq -n --arg stale_days "$STALE_DAYS" '[
-    {"type": "header", "text": {"type": "plain_text", "text": "👀 レビュー待ちPRリマインダー"}},
-    {"type": "section", "text": {"type": "mrkdwn", "text": ($stale_days + "日以上レビューされていないPRがあります:")}},
-    {"type": "divider"}
+# Slackメッセージの構築
+if [[ "$has_my_prs" == "false" && "$has_reviewer_prs" == "false" ]]; then
+  all_blocks=$(jq -n '[
+    {"type": "header", "text": {"type": "plain_text", "text": "👀 PRリマインダー"}},
+    {"type": "section", "text": {"type": "mrkdwn", "text": "対象PRなし"}}
   ]')
-  all_blocks=$(jq -n --argjson header "$header_block" --argjson body "$blocks" '$header + $body')
+else
+  all_blocks=$(jq -n '[
+    {"type": "header", "text": {"type": "plain_text", "text": "👀 PRリマインダー"}}
+  ]')
+
+  if [[ "$has_my_prs" == "true" ]]; then
+    section_header=$(jq -n '[
+      {"type": "section", "text": {"type": "mrkdwn", "text": "── 自分のPR ──"}},
+      {"type": "divider"}
+    ]')
+    all_blocks=$(jq -n --argjson a "$all_blocks" --argjson h "$section_header" --argjson b "$my_pr_blocks" '$a + $h + $b + [{"type": "divider"}]')
+  fi
+
+  if [[ "$has_reviewer_prs" == "true" ]]; then
+    section_header=$(jq -n '[
+      {"type": "section", "text": {"type": "mrkdwn", "text": "── レビュー依頼 ──"}},
+      {"type": "divider"}
+    ]')
+    all_blocks=$(jq -n --argjson a "$all_blocks" --argjson h "$section_header" --argjson b "$reviewer_blocks" '$a + $h + $b + [{"type": "divider"}]')
+  fi
 fi
+
 payload=$(jq -n --argjson blocks "$all_blocks" '{blocks: $blocks}')
 
 response=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/scripts/check-stale-prs.sh
+++ b/scripts/check-stale-prs.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-STALE_DAYS="${STALE_DAYS:-2}"
-SECONDS_PER_DAY=86400
-
 if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
   echo "エラー: SLACK_WEBHOOK_URL が設定されていません"
   exit 1
@@ -25,7 +22,6 @@ if [[ -z "${PR_AUTHOR:-}" ]]; then
 fi
 
 now=$(date +%s)
-threshold=$((STALE_DAYS * SECONDS_PER_DAY))
 
 # 除外対象レビュアーのJSON配列を構築
 ignore_json="[]"
@@ -87,7 +83,7 @@ for repo in "${repos[@]}"; do
   repo_success_count=$((repo_success_count + 1))
 
   # jqフィルタで分類（approved + stale）
-  filtered_prs=$(echo "$prs_with_commits" | jq -r --argjson now "$now" --argjson threshold "$threshold" --argjson ignore_reviewers "$ignore_json" -f "${SCRIPT_DIR}/filter-stale-prs.jq")
+  filtered_prs=$(echo "$prs_with_commits" | jq -r --argjson now "$now" --argjson ignore_reviewers "$ignore_json" -f "${SCRIPT_DIR}/filter-stale-prs.jq")
 
   count=$(echo "$filtered_prs" | jq 'length')
 

--- a/scripts/filter-stale-prs.jq
+++ b/scripts/filter-stale-prs.jq
@@ -1,6 +1,6 @@
-# 放置PRのフィルタリングと分類
+# オープンPRのフィルタリングと分類
 # 入力: gh pr list から取得したPR配列
-# 引数: $now (UNIXタイムスタンプ), $threshold (秒数), $ignore_reviewers (除外対象ログイン名の配列)
+# 引数: $now (UNIXタイムスタンプ), $ignore_reviewers (除外対象ログイン名の配列)
 ($ignore_reviewers // []) as $ignored |
 [.[] | select(.isDraft == false) |
 # 除外対象レビュアーを除去
@@ -39,9 +39,6 @@ else
   else
     { status: "no_reviewer", ref_date: $last_commit }
   end) as $state |
-
-  # 基準日からの経過が閾値を超えているかフィルタ
-  select(($now - $state.ref_date) > $threshold) |
 
   {
     number,

--- a/scripts/filter-stale-prs.jq
+++ b/scripts/filter-stale-prs.jq
@@ -2,44 +2,56 @@
 # 入力: gh pr list から取得したPR配列
 # 引数: $now (UNIXタイムスタンプ), $threshold (秒数), $ignore_reviewers (除外対象ログイン名の配列)
 ($ignore_reviewers // []) as $ignored |
-[.[] | select(
-  .isDraft == false
-  and (.reviewDecision != "APPROVED")
-) |
+[.[] | select(.isDraft == false) |
 # 除外対象レビュアーを除去
 .reviewRequests = [.reviewRequests[]? | select((.login // .name // .slug) as $l | $ignored | index($l) | not)] |
 .latestReviews = [.latestReviews[]? | select(.author.login as $l | $ignored | index($l) | not)] |
 .reviews = [.reviews[]? | select(.author.login as $l | $ignored | index($l) | not)] |
-# ステータス判定フラグ
-(.reviewRequests | length > 0) as $has_request |
-([.latestReviews[]? | select(.state == "CHANGES_REQUESTED")] | length > 0) as $has_changes_requested |
-((.reviews | length) > 0) as $has_reviews |
 
-# ステータスに応じた基準日を算出
-(.commits | last | .committedDate | fromdateiso8601) as $last_commit |
-([.reviews[]? | .submittedAt | fromdateiso8601] | if length > 0 then max else 0 end) as $last_review |
-
-# ステータスと経過日数
-(if $has_changes_requested then
-  { status: "changes_requested", ref_date: $last_review }
-elif $has_request then
-  { status: "review_pending", ref_date: $last_commit }
-elif $has_reviews and ($has_request | not) then
-  { status: "re_request_forgotten", ref_date: $last_commit }
+# APPROVED PRはapprovedステータスで即返却（閾値チェック不要）
+if .reviewDecision == "APPROVED" then
+  {
+    number,
+    title,
+    url,
+    days_elapsed: 0,
+    review_requests: [.reviewRequests[]? | .login // .name // .slug // empty],
+    latest_reviews: [.latestReviews[]? | {author: .author.login, state: .state}],
+    status: "approved"
+  }
 else
-  { status: "no_reviewer", ref_date: $last_commit }
-end) as $state |
+  # ステータス判定フラグ
+  (.reviewRequests | length > 0) as $has_request |
+  ([.latestReviews[]? | select(.state == "CHANGES_REQUESTED")] | length > 0) as $has_changes_requested |
+  ((.reviews | length) > 0) as $has_reviews |
 
-# 基準日からの経過が閾値を超えているかフィルタ
-select(($now - $state.ref_date) > $threshold) |
+  # ステータスに応じた基準日を算出
+  (.commits | last | .committedDate | fromdateiso8601) as $last_commit |
+  ([.reviews[]? | .submittedAt | fromdateiso8601] | if length > 0 then max else 0 end) as $last_review |
 
-{
-  number,
-  title,
-  url,
-  # 86400 = 1日の秒数
-  days_elapsed: ((($now - $state.ref_date) / 86400) | floor),
-  review_requests: [.reviewRequests[]? | .login // .name // .slug // empty],
-  latest_reviews: [.latestReviews[]? | {author: .author.login, state: .state}],
-  status: $state.status
-}] | sort_by(-.days_elapsed)
+  # ステータスと経過日数
+  (if $has_changes_requested then
+    { status: "changes_requested", ref_date: $last_review }
+  elif $has_request then
+    { status: "review_pending", ref_date: $last_commit }
+  elif $has_reviews and ($has_request | not) then
+    { status: "re_request_forgotten", ref_date: $last_commit }
+  else
+    { status: "no_reviewer", ref_date: $last_commit }
+  end) as $state |
+
+  # 基準日からの経過が閾値を超えているかフィルタ
+  select(($now - $state.ref_date) > $threshold) |
+
+  {
+    number,
+    title,
+    url,
+    # 86400 = 1日の秒数
+    days_elapsed: ((($now - $state.ref_date) / 86400) | floor),
+    review_requests: [.reviewRequests[]? | .login // .name // .slug // empty],
+    latest_reviews: [.latestReviews[]? | {author: .author.login, state: .state}],
+    status: $state.status
+  }
+end
+] | sort_by(-.days_elapsed)

--- a/tests/test-filter-stale-prs.sh
+++ b/tests/test-filter-stale-prs.sh
@@ -28,16 +28,12 @@ assert_eq() {
 run_filter() {
   local input="$1"
   local now="$2"
-  local threshold="$3"
-  local ignore="${4:-[]}"
-  echo "$input" | jq --argjson now "$now" --argjson threshold "$threshold" --argjson ignore_reviewers "$ignore" -f "$JQ_FILTER"
+  local ignore="${3:-[]}"
+  echo "$input" | jq --argjson now "$now" --argjson ignore_reviewers "$ignore" -f "$JQ_FILTER"
 }
 
 # テスト基準時刻: 2026-03-17T06:00:00Z
 NOW=1773727200
-# 閾値: 2日（秒数）
-SECONDS_PER_DAY=86400
-THRESHOLD=$((2 * SECONDS_PER_DAY))
 
 # ============================================================
 echo ""
@@ -56,7 +52,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-12T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "ステータスがreview_pending" "review_pending" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "経過日数が5" "5" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 assert_eq "レビュアーがalice" "alice" "$(echo "$result" | jq -r '.[0].review_requests[0]')"
@@ -78,7 +74,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-07T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "ステータスがchanges_requested" "changes_requested" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "経過日数が3（最終レビュー基準、コミットではない）" "3" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
@@ -99,7 +95,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-05T06:00:00Z"}, {"committedDate": "2026-03-13T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "ステータスがre_request_forgotten" "re_request_forgotten" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "経過日数が4（最終コミット基準）" "4" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
@@ -120,7 +116,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-11T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "ステータスがno_reviewer" "no_reviewer" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "経過日数が6" "6" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
@@ -140,7 +136,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-10T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "DraftPRは除外される" "0" "$(echo "$result" | jq 'length')"
 
 # ============================================================
@@ -159,15 +155,15 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-05T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "APPROVEDなPRは1件返る" "1" "$(echo "$result" | jq 'length')"
 assert_eq "ステータスがapproved" "approved" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "days_elapsedが0" "0" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""
-echo "=== Case 7: 閾値以内のPRは除外される ==="
-# 最終コミット: 1日前（2日閾値以内）
+echo "=== Case 7: 作成直後のPRも返る ==="
+# 最終コミット: 1日前
 INPUT='[{
   "number": 700,
   "title": "feat: fresh PR",
@@ -181,12 +177,14 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-16T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
-assert_eq "閾値以内のPRは除外される" "0" "$(echo "$result" | jq 'length')"
+result=$(run_filter "$INPUT" "$NOW")
+assert_eq "作成直後のPRも返る" "1" "$(echo "$result" | jq 'length')"
+assert_eq "ステータスがreview_pending" "review_pending" "$(echo "$result" | jq -r '.[0].status')"
+assert_eq "経過日数が1" "1" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""
-echo "=== Case 8: 古いPRでも最近コミットしたら除外 ==="
+echo "=== Case 8: 古いPRで最近コミットしたものも返る ==="
 # 作成30日前、最終コミットは昨日
 INPUT='[{
   "number": 800,
@@ -201,12 +199,13 @@ INPUT='[{
   "commits": [{"committedDate": "2026-02-15T00:00:00Z"}, {"committedDate": "2026-03-16T12:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
-assert_eq "古いPRでも最近コミットしたら除外" "0" "$(echo "$result" | jq 'length')"
+result=$(run_filter "$INPUT" "$NOW")
+assert_eq "古いPRで最近コミットしたものも返る" "1" "$(echo "$result" | jq 'length')"
+assert_eq "経過日数は最終コミット基準で0" "0" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""
-echo "=== Case 9: 修正待ちで最近レビューされたら除外 ==="
+echo "=== Case 9: 修正待ちで最近レビューされたものも返る ==="
 # CHANGES_REQUESTEDが昨日
 INPUT='[{
   "number": 900,
@@ -221,8 +220,10 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-01T00:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
-assert_eq "最近レビューされた修正待ちは除外" "0" "$(echo "$result" | jq 'length')"
+result=$(run_filter "$INPUT" "$NOW")
+assert_eq "最近レビューされた修正待ちも返る" "1" "$(echo "$result" | jq 'length')"
+assert_eq "ステータスがchanges_requested" "changes_requested" "$(echo "$result" | jq -r '.[0].status')"
+assert_eq "経過日数が0（最終レビュー基準）" "0" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""
@@ -254,7 +255,7 @@ INPUT='[
   }
 ]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "2件のPRが返る" "2" "$(echo "$result" | jq 'length')"
 assert_eq "経過日数が多いPRが先" "1002" "$(echo "$result" | jq -r '.[0].number')"
 assert_eq "経過日数が少ないPRが後" "1001" "$(echo "$result" | jq -r '.[1].number')"
@@ -276,7 +277,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-10T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 # botレビューはhas_reviews=true + reviewRequestsなし → re_request_forgotten
 assert_eq "botのみレビュー → re_request_forgotten" "re_request_forgotten" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "経過日数が7（最終コミット基準）" "7" "$(echo "$result" | jq -r '.[0].days_elapsed')"
@@ -298,14 +299,14 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-12T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
+result=$(run_filter "$INPUT" "$NOW")
 assert_eq "changes_requestedが優先" "changes_requested" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "最終レビューからの経過日数が7" "7" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""
 echo "=== Case 13: 空配列 ==="
-result=$(run_filter "[]" "$NOW" "$THRESHOLD")
+result=$(run_filter "[]" "$NOW")
 assert_eq "空配列は空を返す" "0" "$(echo "$result" | jq 'length')"
 
 # ============================================================
@@ -324,7 +325,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-10T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD" '["aws-security-agent"]')
+result=$(run_filter "$INPUT" "$NOW" '["aws-security-agent"]')
 assert_eq "bot除外 → no_reviewer（re_request_forgottenではない）" "no_reviewer" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "botがlatest_reviewsに含まれない" "0" "$(echo "$result" | jq '.[0].latest_reviews | length')"
 
@@ -350,7 +351,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-10T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD" '["aws-security-agent"]')
+result=$(run_filter "$INPUT" "$NOW" '["aws-security-agent"]')
 assert_eq "人間レビュアーが残る → review_pending" "review_pending" "$(echo "$result" | jq -r '.[0].status')"
 assert_eq "aliceがreview_requestsに含まれる" "alice" "$(echo "$result" | jq -r '.[0].review_requests[0]')"
 
@@ -370,7 +371,7 @@ INPUT='[{
   "commits": [{"committedDate": "2026-03-10T06:00:00Z"}]
 }]'
 
-result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD" '[]')
+result=$(run_filter "$INPUT" "$NOW" '[]')
 assert_eq "空の除外リストではbotが残る" "re_request_forgotten" "$(echo "$result" | jq -r '.[0].status')"
 
 # ============================================================

--- a/tests/test-filter-stale-prs.sh
+++ b/tests/test-filter-stale-prs.sh
@@ -145,7 +145,7 @@ assert_eq "DraftPRは除外される" "0" "$(echo "$result" | jq 'length')"
 
 # ============================================================
 echo ""
-echo "=== Case 6: APPROVEDは除外される ==="
+echo "=== Case 6: APPROVEDはapprovedステータスで返る ==="
 INPUT='[{
   "number": 600,
   "title": "feat: approved one",
@@ -160,7 +160,9 @@ INPUT='[{
 }]'
 
 result=$(run_filter "$INPUT" "$NOW" "$THRESHOLD")
-assert_eq "APPROVEDなPRは除外される" "0" "$(echo "$result" | jq 'length')"
+assert_eq "APPROVEDなPRは1件返る" "1" "$(echo "$result" | jq 'length')"
+assert_eq "ステータスがapproved" "approved" "$(echo "$result" | jq -r '.[0].status')"
+assert_eq "days_elapsedが0" "0" "$(echo "$result" | jq -r '.[0].days_elapsed')"
 
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary
- STALE_DAYS閾値フィルタを廃止し、経過日数に関係なく全オープンPRのステータスを通知対象にする
- 実行スケジュールを平日毎日→月・水・金に変更
- approve済みPR通知とレビュー依頼通知を追加（先行コミット）

## Test plan
- [x] 全34テストケース通過確認済み
- [ ] 手動実行（workflow_dispatch）でSlack通知を確認